### PR TITLE
`/payment-key` API is now support Passport items

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,5 +39,5 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'off',
     },
   },
-  { ignores: ['dist', '.yarn', '*.d.ts'] },
+  { ignores: ['dist', '.yarn', '.astro', '*.d.ts'] },
 )

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@astrojs/tailwind": "5.1.3",
     "@astrojs/vue": "5.0.2",
     "@devprotocol/clubs-core": "3.22.2",
+    "@devprotocol/clubs-plugin-passports": "0.1.0-beta.33",
     "@eslint/js": "^9.13.0",
     "@rollup/plugin-typescript": "^12.1.1",
     "@tailwindcss/typography": "^0.5.15",
@@ -92,6 +93,7 @@
   },
   "peerDependencies": {
     "@devprotocol/clubs-core": "^3.22.1",
+    "@devprotocol/clubs-plugin-passports": "^0.1.0-beta.33",
     "ethers": "^6.0.0"
   },
   "repository": "https://github.com/dev-protocol/clubs-plugin-payments.git",

--- a/src/api/payment-key.ts
+++ b/src/api/payment-key.ts
@@ -21,7 +21,7 @@ import { createClient } from 'redis'
 import { generateFulFillmentParamsId } from '../utils/gen-key'
 import {
   bytes32Hex,
-  ClubsConfiguration,
+  type ClubsConfiguration,
   getTokenAddress,
 } from '@devprotocol/clubs-core'
 import { replaceWithFwdHost } from '../fixtures/url'

--- a/src/api/payment-key.ts
+++ b/src/api/payment-key.ts
@@ -11,11 +11,21 @@ import {
 import BigNumber from 'bignumber.js'
 import { abi } from './fulfillment'
 import type { ComposedItem } from '..'
-import { whenNotError, whenNotErrorAll } from '@devprotocol/util-ts'
+import {
+  isNotError,
+  whenDefinedAll,
+  whenNotError,
+  whenNotErrorAll,
+} from '@devprotocol/util-ts'
 import { createClient } from 'redis'
 import { generateFulFillmentParamsId } from '../utils/gen-key'
-import { bytes32Hex, getTokenAddress } from '@devprotocol/clubs-core'
+import {
+  bytes32Hex,
+  ClubsConfiguration,
+  getTokenAddress,
+} from '@devprotocol/clubs-core'
 import { replaceWithFwdHost } from '../fixtures/url'
+import { composePassportItem } from '../utils/compose-passport-item'
 
 const { POP_SERVER_KEY, REDIS_URL, REDIS_USERNAME, REDIS_PASSWORD } =
   import.meta.env
@@ -111,15 +121,17 @@ export type PaymentKeyOptions = {
  * ?id={MEMBERSHIP_ID}&eoa={USER_EOA}&email.customer_name={USER_NAME}&email.customer_email_address={USER_EMAIL_ADDRESS}&dummy={OPTIONAL_BOOLEAN}
  */
 export const get: ({
+  config,
   propertyAddress,
   chainId,
   items,
 }: {
+  config: ClubsConfiguration
   propertyAddress: string
   chainId: number
   items: ComposedItem[]
 }) => APIRoute =
-  ({ propertyAddress, chainId, items: _items }) =>
+  ({ config, propertyAddress, chainId, items: _items }) =>
   async ({ url, request }) => {
     /**
      * Get request parameters.
@@ -132,11 +144,29 @@ export const get: ({
       'email.customer_email_address',
     )
 
+    const client = await whenNotError(
+      createClient({
+        url: REDIS_URL,
+        username: REDIS_USERNAME ?? '',
+        password: REDIS_PASSWORD ?? '',
+      }),
+      (db) =>
+        db
+          .connect()
+          .then(() => db)
+          .catch((err) => new Error(err)),
+    )
+
     /**
      * Get the expected overridden membership and its source.
      */
     const membership =
       _items.find((mem) => bytes32Hex(mem.payload) === offeringPayload) ??
+      (await whenDefinedAll([offeringPayload, client], ([payload, redis]) =>
+        isNotError(redis)
+          ? composePassportItem(payload, { config, client: redis })
+          : undefined,
+      )) ??
       new Error('Missing item ID')
 
     const payloadHex = whenNotError(membership, bytes32Hex)
@@ -192,19 +222,6 @@ export const get: ({
       `/api/devprotocol:clubs:plugin:clubs-payments/fulfillment`,
       new URL(currentUrl).origin.replace('http:', 'https:'),
     ).toString()
-
-    const client = await whenNotError(
-      createClient({
-        url: REDIS_URL,
-        username: REDIS_USERNAME ?? '',
-        password: REDIS_PASSWORD ?? '',
-      }),
-      (db) =>
-        db
-          .connect()
-          .then(() => db)
-          .catch((err) => new Error(err)),
-    )
 
     const paramsSaved = await whenNotErrorAll(
       [client, abiEncodedParamsForFulfilment],

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,11 +76,8 @@ export const getAdminPaths = (async (options, { name, offerings }, utils) => {
   ]
 }) satisfies ClubsFunctionGetAdminPaths
 
-export const getApiPaths = (async (
-  options,
-  { propertyAddress, chainId, rpcUrl, offerings },
-  utils,
-) => {
+export const getApiPaths = (async (options, config, utils) => {
+  const { propertyAddress, chainId, rpcUrl, offerings } = config
   const items = composeItems(options, utils, offerings)
   const webhooks =
     (options.find((opt) => opt.key === 'webhooks')?.value as UndefinedOr<{
@@ -96,7 +93,7 @@ export const getApiPaths = (async (
     {
       paths: ['payment-key'],
       method: 'GET',
-      handler: get({ items, propertyAddress, chainId }),
+      handler: get({ config, items, propertyAddress, chainId }),
     },
     {
       paths: ['fulfillment'],

--- a/src/utils/compose-passport-item.ts
+++ b/src/utils/compose-passport-item.ts
@@ -1,0 +1,35 @@
+import { createClient } from 'redis'
+import type { ComposedItem } from '..'
+import { ClubsConfiguration } from '@devprotocol/clubs-core'
+import { checkoutPassportItemForPayload } from '@devprotocol/clubs-plugin-passports'
+import { UndefinedOr, whenDefinedAll } from '@devprotocol/util-ts'
+
+export const composePassportItem = async (
+  payload: Uint8Array | string,
+  {
+    config,
+    client,
+  }: {
+    config: ClubsConfiguration
+    client: Awaited<ReturnType<typeof createClient>>
+  },
+): Promise<UndefinedOr<ComposedItem>> => {
+  const passportItem = await checkoutPassportItemForPayload(payload, {
+    config,
+    client,
+  })
+  return whenDefinedAll(
+    [
+      passportItem,
+      passportItem?.props.discount?.price.yen ??
+        passportItem?.props.fiat.price.yen,
+    ],
+    ([item, yen]) => ({
+      payload,
+      price: {
+        yen,
+      },
+      source: item.props.offering,
+    }),
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,6 +614,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@devprotocol/clubs-plugin-passports@npm:0.1.0-beta.33":
+  version: 0.1.0-beta.33
+  resolution: "@devprotocol/clubs-plugin-passports@npm:0.1.0-beta.33"
+  dependencies:
+    "@devprotocol/dev-kit": "npm:8.7.0"
+    "@devprotocol/util-ts": "npm:4.0.0"
+    bignumber.js: "npm:9.1.2"
+    dayjs: "npm:^1.11.13"
+    nanoid: "npm:^5.0.7"
+    ramda: "npm:0.30.1"
+    redis: "npm:^4.7.0"
+    sass: "npm:1.83.0"
+  peerDependencies:
+    "@devprotocol/clubs-core": ^3.18.0
+    "@devprotocol/clubs-plugin-payments": ^0.2.3
+    ethers: ^6.0.0
+  checksum: 10c0/705e17ba99bf313d0191c7e67da2feff47ed4ce2dc5d3822006c4980b6fef4bf1c1b1c93bff29051e5d15f872cd31b36a2e09c7a90a6230b3fd2a4ef7b2af0b6
+  languageName: node
+  linkType: hard
+
 "@devprotocol/clubs-plugin-payments@workspace:.":
   version: 0.0.0-use.local
   resolution: "@devprotocol/clubs-plugin-payments@workspace:."
@@ -623,6 +643,7 @@ __metadata:
     "@astrojs/tailwind": "npm:5.1.3"
     "@astrojs/vue": "npm:5.0.2"
     "@devprotocol/clubs-core": "npm:3.22.2"
+    "@devprotocol/clubs-plugin-passports": "npm:0.1.0-beta.33"
     "@devprotocol/dev-kit": "npm:8.7.0"
     "@devprotocol/util-ts": "npm:4.0.0"
     "@eslint/js": "npm:^9.13.0"
@@ -668,6 +689,7 @@ __metadata:
     vue-tsc: "npm:^2.0.0"
   peerDependencies:
     "@devprotocol/clubs-core": ^3.22.1
+    "@devprotocol/clubs-plugin-passports": ^0.1.0-beta.33
     ethers: ^6.0.0
   languageName: unknown
   linkType: soft
@@ -3962,6 +3984,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dayjs@npm:^1.11.13":
+  version: 1.11.13
+  resolution: "dayjs@npm:1.11.13"
+  checksum: 10c0/a3caf6ac8363c7dade9d1ee797848ddcf25c1ace68d9fe8678ecf8ba0675825430de5d793672ec87b24a69bf04a1544b176547b2539982275d5542a7955f35b7
+  languageName: node
+  linkType: hard
+
 "de-indent@npm:^1.0.2":
   version: 1.0.2
   resolution: "de-indent@npm:1.0.2"
@@ -7020,7 +7049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^5.0.9":
+"nanoid@npm:^5.0.7, nanoid@npm:^5.0.9":
   version: 5.0.9
   resolution: "nanoid@npm:5.0.9"
   bin:
@@ -7886,7 +7915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redis@npm:4.7.0":
+"redis@npm:4.7.0, redis@npm:^4.7.0":
   version: 4.7.0
   resolution: "redis@npm:4.7.0"
   dependencies:
@@ -8337,7 +8366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:^1.80.4":
+"sass@npm:1.83.0, sass@npm:^1.80.4":
   version: 1.83.0
   resolution: "sass@npm:1.83.0"
   dependencies:


### PR DESCRIPTION
Passport items now accept CC payments without prior configuration.